### PR TITLE
25754 persist filter options url

### DIFF
--- a/app/controllers/onlylogs/logs_controller.rb
+++ b/app/controllers/onlylogs/logs_controller.rb
@@ -10,6 +10,7 @@ module Onlylogs
 
       @filter = params[:filter]
       @autoscroll = params[:autoscroll] != "false"
+      @regexp_mode = params[:regexp_mode] == "true"
       @mode = @filter.blank? ? (params[:mode] || "live") : "search" # "live" or "search"
     end
 

--- a/app/javascript/onlylogs/controllers/log_streamer_controller.js
+++ b/app/javascript/onlylogs/controllers/log_streamer_controller.js
@@ -86,13 +86,13 @@ export default class LogStreamerController extends Controller {
 
   toggleAutoScroll() {
     this.autoScrollValue = !this.autoScrollValue;
-    this.#updateUrlParams();
+    this.#updateUrlParam('autoscroll', this.autoScrollValue ? null : 'false');
     this.scroll();
   }
 
   toggleRegexpMode() {
     this.regexpModeValue = this.regexpModeTarget.checked;
-    this.#updateUrlParams();
+    this.#updateUrlParam('regexp_mode', this.regexpModeValue ? 'true' : null);
     // If we have a filter applied, reconnect to apply the new regexp mode
     if (this.filterInputTarget.value && this.filterInputTarget.value.trim() !== '') {
       this.reconnectWithNewMode();
@@ -114,8 +114,10 @@ export default class LogStreamerController extends Controller {
   }
 
   applyFilter() {
+    const filterValue = this.filterInputTarget.value;
+
     // If filter is applied, disable live mode
-    if (this.filterInputTarget.value && this.filterInputTarget.value.trim() !== '') {
+    if (filterValue && filterValue.trim() !== '') {
       this.liveModeTarget.checked = false;
       this.modeValue = 'search';
     } else {
@@ -127,8 +129,7 @@ export default class LogStreamerController extends Controller {
     // Update visual state
     this.updateLiveModeState();
     this.updateStopButtonVisibility();
-
-    this.#updateUrlParams();
+    this.#updateUrlParam('filter', filterValue || null);
 
     // Use the global debounced reconnection (300ms delay)
     this.reconnectWithNewMode();
@@ -173,7 +174,7 @@ export default class LogStreamerController extends Controller {
     this.updateStopButtonVisibility();
 
     // Update URL with cleared filter
-    this.#updateUrlParams();
+    this.#updateUrlParam('filter');
 
     // Reconnect with cleared filter and live mode
     this.reconnectWithNewMode();
@@ -398,32 +399,15 @@ export default class LogStreamerController extends Controller {
     this.#initializeClusterize();
   }
 
-  #updateUrlParams() {
+  #updateUrlParam(param, value = null) {
     const params = new URLSearchParams(window.location.search);
 
-    // Update or remove filter parameter
-    const filterValue = this.filterInputTarget.value;
-    if (filterValue && filterValue.trim() !== '') {
-      params.set('filter', filterValue);
+    if (value != null) {
+      params.set(param, value);
     } else {
-      params.delete('filter');
+      params.delete(param);
     }
 
-    // Update autoscroll parameter
-    if (!this.autoScrollValue) {
-      params.set('autoscroll', 'false');
-    } else {
-      params.delete('autoscroll');
-    }
-
-    // Update regexp mode parameter
-    if (this.regexpModeValue) {
-      params.set('regexp_mode', 'true');
-    } else {
-      params.delete('regexp_mode');
-    }
-
-    // Update the URL without reloading the page
     const newUrl = `${window.location.pathname}?${params.toString()}`;
     window.history.replaceState(null, '', newUrl);
   }

--- a/app/javascript/onlylogs/controllers/log_streamer_controller.js
+++ b/app/javascript/onlylogs/controllers/log_streamer_controller.js
@@ -86,11 +86,13 @@ export default class LogStreamerController extends Controller {
 
   toggleAutoScroll() {
     this.autoScrollValue = !this.autoScrollValue;
+    this.#updateUrlParams();
     this.scroll();
   }
 
   toggleRegexpMode() {
     this.regexpModeValue = this.regexpModeTarget.checked;
+    this.#updateUrlParams();
     // If we have a filter applied, reconnect to apply the new regexp mode
     if (this.filterInputTarget.value && this.filterInputTarget.value.trim() !== '') {
       this.reconnectWithNewMode();
@@ -125,6 +127,8 @@ export default class LogStreamerController extends Controller {
     // Update visual state
     this.updateLiveModeState();
     this.updateStopButtonVisibility();
+
+    this.#updateUrlParams();
 
     // Use the global debounced reconnection (300ms delay)
     this.reconnectWithNewMode();
@@ -167,6 +171,9 @@ export default class LogStreamerController extends Controller {
     // Update visual state
     this.updateLiveModeState();
     this.updateStopButtonVisibility();
+
+    // Update URL with cleared filter
+    this.#updateUrlParams();
 
     // Reconnect with cleared filter and live mode
     this.reconnectWithNewMode();
@@ -389,5 +396,35 @@ export default class LogStreamerController extends Controller {
     this.clusterize.destroy();
     this.clusterize = null;
     this.#initializeClusterize();
+  }
+
+  #updateUrlParams() {
+    const params = new URLSearchParams(window.location.search);
+
+    // Update or remove filter parameter
+    const filterValue = this.filterInputTarget.value;
+    if (filterValue && filterValue.trim() !== '') {
+      params.set('filter', filterValue);
+    } else {
+      params.delete('filter');
+    }
+
+    // Update autoscroll parameter
+    if (!this.autoScrollValue) {
+      params.set('autoscroll', 'false');
+    } else {
+      params.delete('autoscroll');
+    }
+
+    // Update regexp mode parameter
+    if (this.regexpModeValue) {
+      params.set('regexp_mode', 'true');
+    } else {
+      params.delete('regexp_mode');
+    }
+
+    // Update the URL without reloading the page
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState(null, '', newUrl);
   }
 }

--- a/app/views/onlylogs/logs/index.html.erb
+++ b/app/views/onlylogs/logs/index.html.erb
@@ -36,5 +36,5 @@
       <% end %>
     <% end %>
   </div>
-  <%= render partial: "onlylogs/shared/log_container", locals: { log_file_path: @log_file_path, tail: @max_lines, filter: @filter, autoscroll: @autoscroll } %>
+  <%= render partial: "onlylogs/shared/log_container", locals: { log_file_path: @log_file_path, tail: @max_lines, filter: @filter, autoscroll: @autoscroll, regexp_mode: @regexp_mode } %>
 </div>

--- a/app/views/onlylogs/shared/_log_container.html.erb
+++ b/app/views/onlylogs/shared/_log_container.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (log_file_path:, tail: 100, filter: "", autoscroll: true) %>
+<%# locals: (log_file_path:, tail: 100, filter: "", autoscroll: true, regexp_mode: false) %>
 <script nonce="<%= request.content_security_policy_nonce %>"
         src="https://cdn.jsdelivr.net/npm/clusterize.js@0.18.1/clusterize.min.js"></script>
 <%= render "onlylogs/shared/log_container_styles" %>
@@ -17,6 +17,7 @@
      data-log-streamer-cursor-position-value="<%= cursor_position %>"
      data-log-streamer-filter-value="<%= filter %>"
      data-log-streamer-auto-scroll-value="<%= autoscroll %>"
+     data-log-streamer-regexp-mode-value="<%= regexp_mode %>"
      data-log-streamer-mode-value="<%= mode %>"
      class="onlylogs-log-container" >
     <div data-log-streamer-target="logLines" data-text-selection-target="logLines" id="scrollArea" class="onlylogs-log-lines clusterize-scroll">
@@ -48,7 +49,7 @@
         </div>
         <div>
           <label style="margin-bottom: 0;">
-            <input id="regexpMode" type="checkbox" name="regexpMode" data-log-streamer-target="regexpMode" data-text-selection-target="regexpMode" data-action="change->log-streamer#toggleRegexpMode">
+            <input id="regexpMode" type="checkbox" <%= regexp_mode ? "checked" : "" %> name="regexpMode" data-log-streamer-target="regexpMode" data-text-selection-target="regexpMode" data-action="change->log-streamer#toggleRegexpMode">
             <u>R</u>egexp Mode
           </label>
         </div>

--- a/test/controllers/onlylogs/logs_controller_test.rb
+++ b/test/controllers/onlylogs/logs_controller_test.rb
@@ -107,5 +107,13 @@ module Onlylogs
       get "/onlylogs/download", params: {log_file_path: "invalid_encrypted_string"}
       assert_response :bad_request
     end
+
+    test "index persists multiple parameters together" do
+      get "/onlylogs", params: {filter: "warning", autoscroll: "false", regexp_mode: "true"}
+      assert_response :success
+      assert_select "[data-log-streamer-filter-value='warning']"
+      assert_select "[data-log-streamer-auto-scroll-value='false']"
+      assert_select "[data-log-streamer-regexp-mode-value='true']"
+    end
   end
 end


### PR DESCRIPTION
TICKET-25754

Persist search parameters (filter, autoscroll, regexp_mode) in the URL so users can refresh the page and see the same results. Parameters are also shareable via URL.

To test it locally, change line 18 in test/dummy/app/views/home/show.html.erb from 
`<h3><%= link_to file_name, log_viewer_path(encrypted_path) %></h3>` 
To 
`<h3><%= link_to file_name, onlylogs_path(encrypted_path) %></h3>`


